### PR TITLE
chore: remove fix-use-guides, since we no longer depend on that branch

### DIFF
--- a/mobile.angular.io/package.json
+++ b/mobile.angular.io/package.json
@@ -15,6 +15,6 @@
   "license": "MIT",
   "dependencies": {
     "material-design-lite": "^1.1.3",
-    "microsite-ui": "git://github.com/angular/design-love.git#fix-use-guides"
+    "microsite-ui": "git://github.com/angular/design-love.git"
   }
 }


### PR DESCRIPTION
#### Changes
- This is telling the package file to no longer use the fix-use-guides branch since we've assimilated guides into the main build.

@amitafr 
