### PR TITLE
fix(cli): it's just Angular

### DIFF
--- a/cli.angular.io/index.ejs
+++ b/cli.angular.io/index.ejs
@@ -41,7 +41,7 @@
       <%- partial("node_modules/microsite-ui/_partials/features", {
         features: [{
           name: 'ng new',
-          text: 'The Angular2 CLI makes it easy to create an application that already works, right out of the box. It already follows our best practices!'
+          text: 'The Angular CLI makes it easy to create an application that already works, right out of the box. It already follows our best practices!'
         }, {
           name: 'ng generate',
           text: 'Generate components, routes, services and pipes with a simple command. The CLI will also create simple test shells for all of these.'
@@ -50,7 +50,7 @@
           text: 'Easily put your application in production'
         }, {
           name: 'Test, Lint, Format',
-          text: 'Make your code really shine. Run your unittests or your end-to-end tests with the breeze of a command. Execute the official Angular2 linter and run clang format.'
+          text: 'Make your code really shine. Run your unittests or your end-to-end tests with the breeze of a command. Execute the official Angular linter and run clang format.'
         }],
         CTA: {
           text: 'Get Started',


### PR DESCRIPTION
I noticed that the image was recently fixed https://github.com/angular/microsites/commit/2ee9be455086d38518c1cafc9787db9e844aecdd, but the text was still referencing Angular2.

Other microsites have the same problem, I can open other PRs if you want the problem fixed everywhere