### PR TITLE
Change "Angular 2" into "Angular.io"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Microsites
-A monorepo containing all Angular 2 microsites.
+A monorepo containing all Angular.io microsites.
 
 ## Dependencies
 * [Harp.js](http://harpjs.com/), a static web server with a built-in preprocessor.


### PR DESCRIPTION
As Angular team [said](https://twitter.com/IgorMinar/status/807564427113492480), using version number is not recommended. Only acceptable if it refers to version specific issues. This is not that scenario.
